### PR TITLE
Resolves issue 27

### DIFF
--- a/static/css/CardComponent.scss
+++ b/static/css/CardComponent.scss
@@ -52,9 +52,16 @@
 
 }
 
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .card-body {
   .card-title {
-    font-size: 23px;
+    width: 40%;
+    font-size: 18px;
     margin-left: 16px;
     margin-top: 24px;
     margin-bottom: 24px;
@@ -62,6 +69,7 @@
   }
 
   .card-icons {
+    width: 60%;
     margin-left: 16px;
     margin-top: 24px;
     margin-bottom: 24px;

--- a/static/css/CardComponent.scss
+++ b/static/css/CardComponent.scss
@@ -25,6 +25,11 @@
   padding-left: 4px;
 }
 
+  a:hover, a:visited, a:link, a:active {
+    text-decoration: none !important;
+    color: inherit;
+  }
+
 .rs-card {
   border-radius: 2px;
   background-color: white;

--- a/static/js/components/CardComponent.js
+++ b/static/js/components/CardComponent.js
@@ -13,7 +13,7 @@ export default class CardComponent extends Component {
                     </div>
                     <div className="card-body">
                         <div className="card-title-contents">
-                            <h5 className="card-title">{ this.props.item.name }</h5>
+                            <h5 className="card-title truncate">{ this.props.item.name }</h5>
                             <div className="card-icons">
                                 { this.props.item.reddits.length > 0 && <img src="/static/img/reddit-1.svg"/> }
                                 { this.props.item.videos.length > 0 && <img src="/static/img/YouTube-small-full_color_light.svg"/> }

--- a/static/js/components/CardComponent.js
+++ b/static/js/components/CardComponent.js
@@ -7,6 +7,7 @@ export default class CardComponent extends Component {
     render() {
         return (
             <div className="col-md-3 col-sm-12">
+                <a href={'/items/' + this.props.item.id}>
                 <div className="rs-card">
                     <div className="card-img-container">
                         <img src={ this.props.item.icon } className="card-img-top" />
@@ -21,6 +22,7 @@ export default class CardComponent extends Component {
                         </div>
                   </div>
                 </div>
+                </a>
             </div>
         );
     }


### PR DESCRIPTION
User can click a card and be redirected to the items detail page. As of right now, entire card is clickable. Also added some CSS to prevent card titles from overflowing and cause card height to increase. Currently truncates title with ellipses 